### PR TITLE
fix: null page

### DIFF
--- a/lib/carousel_slider_plus.dart
+++ b/lib/carousel_slider_plus.dart
@@ -165,6 +165,8 @@ class _CarouselSliderState extends State<CarouselSlider>
       final route = ModalRoute.of(context);
       if (route?.isCurrent == false) return;
 
+      if (!state.pageController.hasClients) return;
+
       CarouselPageChangedReason previousReason = mode;
       changeMode(CarouselPageChangedReason.timed);
       int nextPage = state.pageController.page!.round() + 1;

--- a/lib/carousel_slider_plus.dart
+++ b/lib/carousel_slider_plus.dart
@@ -165,7 +165,6 @@ class _CarouselSliderState extends State<CarouselSlider>
       final route = ModalRoute.of(context);
       if (route?.isCurrent == false) return;
 
-      if (!state.pageController.hasClients) return;
       if (!state.pageController.hasClients || state.pageController.page == null) return;
 
       CarouselPageChangedReason previousReason = mode;

--- a/lib/carousel_slider_plus.dart
+++ b/lib/carousel_slider_plus.dart
@@ -166,6 +166,7 @@ class _CarouselSliderState extends State<CarouselSlider>
       if (route?.isCurrent == false) return;
 
       if (!state.pageController.hasClients) return;
+      if (!state.pageController.hasClients || state.pageController.page == null) return;
 
       CarouselPageChangedReason previousReason = mode;
       changeMode(CarouselPageChangedReason.timed);

--- a/lib/carousel_slider_plus.dart
+++ b/lib/carousel_slider_plus.dart
@@ -157,15 +157,13 @@ class _CarouselSliderState extends State<CarouselSlider>
   Timer? getTimer() {
     if (!widget.options.autoPlay) return null;
     return Timer.periodic(widget.options.autoPlayInterval, (_) {
-      if (!mounted) {
+      if (!mounted || !state.pageController.hasClients || state.pageController.page == null) {
         clearTimer();
         return;
       }
 
       final route = ModalRoute.of(context);
       if (route?.isCurrent == false) return;
-
-      if (!state.pageController.hasClients || state.pageController.page == null) return;
 
       CarouselPageChangedReason previousReason = mode;
       changeMode(CarouselPageChangedReason.timed);


### PR DESCRIPTION
This PR fixes this issue (raised here #10 ):

```
Non-fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Null check operator used on a null value
#00 pc 0x623d53 com.cashea.app (_CarouselSliderState.getTimer.<anonymous closure> [carousel_slider_plus.dart:170])
```

which is caused when accessing a null page, in this line:
`int nextPage = state.pageController.page!.round() + 1;`

As per Flutter docs:

> There are circumstances that this [PageController] can't know the current page. Reading [page] will throw an [AssertionError] in the following cases:
> 
> No [PageView] is currently using this [PageController]. Once a [PageView] starts using this [PageController], the new [page] position will be derived:
> First, based on the attached [PageView]'s [BuildContext] and the position saved at that context's [PageStorage] if [keepPage] is true.
> Second, from the [PageController]'s [initialPage].
> More than one [PageView] using the same [PageController].
> The [hasClients] property can be used to check if a [PageView] is attached prior to accessing [page].
> 

So the fix is a guard that checks if the controller has clients.